### PR TITLE
Add setter for costs that opperates directly on a node list

### DIFF
--- a/solver_backend/__init__.py
+++ b/solver_backend/__init__.py
@@ -1,5 +1,5 @@
 from .solver_utils import preprocess_with_simple_statistics, preprocess_with_random_forest, preprocess_with_callback, solve_multicut
 from .probability_callbacks import compute_edge_features
 from .random_forest import learn_rf
-from .interactive_backend import set_costs_from_uv_ids, SolverServer
+from .interactive_backend import set_costs_from_uv_ids, SolverServer, set_costs_from_node_list
 from .utils import read_hdf5

--- a/solver_backend/interactive_backend.py
+++ b/solver_backend/interactive_backend.py
@@ -26,7 +26,7 @@ class SolverServer( object ):
 	def __init__( self, graph, costs, address, initial_solution, repulsive_cost=-100, attractive_cost=+100 ):
 
 	    super( SolverServer, self ).__init__()
-	    
+
 	    self.logger = logging.getLogger( __name__ )
 	    self.logger.debug( 'Instantiating server!' )
 
@@ -59,7 +59,7 @@ class SolverServer( object ):
 
 	def start( self, ioThreads=1, timeout=10 ):
 
-	    
+
 		self.logger.debug( 'Starting server!' )
 		with self.lock:
 			if not self.is_running():
@@ -96,8 +96,11 @@ class SolverServer( object ):
 
 	def _merge( self, *ids ):
 		# https://stackoverflow.com/a/942551/1725687
-		node_pairs = np.array( list( itertools.combinations( ids, 2 ) ) )
-		set_costs_from_uv_ids( self.graph, self.costs, node_pairs.astype(np.int32), self.attractive_cost )
+		#node_pairs = np.array( list( itertools.combinations( ids, 2 ) ) )
+		#set_costs_from_uv_ids( self.graph, self.costs, node_pairs.astype(np.int32), self.attractive_cost )
+                # new faster version
+                set_costs_from_node_list( self.graph, self.costs, node_pairs.astype(np.int32), self.attractive_cost )
+
 
 	def _detach( self, fragment_id, *detach_from ):
 		if len( detach_from ) == 0:
@@ -155,6 +158,11 @@ def set_costs_from_uv_ids(graph, costs, uv_pairs, values):
     # print( 'any valid edges', valid_edges, np.any( valid_edges ) )
 
     costs[edge_ids] = values[ valid_edges ] if isinstance( values, (np.ndarray, list, tuple) ) else values
+
+
+def set_costs_from_node_list(graph, costs, node_list, value):
+    edge_ids = graph.edgesFromNodeList(node_list)
+    costs[edge_ids] = value
 
 
 def set_costs_from_cluster_ids(graph, costs, node_labeling, cluster_u, cluster_v, value):

--- a/test/test_cost_setters.py
+++ b/test/test_cost_setters.py
@@ -1,0 +1,49 @@
+import time
+import unittest
+import numpy as np
+import nifty
+import itertools
+
+# hacky import
+import sys
+sys.path.append('..')
+from solver_backend import set_costs_from_uv_ids, set_costs_from_node_list
+
+
+class TestCostSetters(unittest.TestCase):
+
+    def random_graph(self):
+        n_nodes = 10000
+        n_edges = 10 * n_nodes
+        graph = nifty.graph.UndirectedGraph(n_nodes)
+        edges = np.random.choice(n_nodes, size=2 * n_edges).reshape((n_edges, 2)).astype('int32')
+        # remove duplicate edges
+        unique_pairs = edges[:, 0] != edges[:, 1]
+        edges = edges[unique_pairs]
+        graph.insertEdges(edges)
+        return graph
+
+    def test_cost_setters(self):
+        graph = self.random_graph()
+        costs1 = np.random.rand(graph.numberOfEdges)
+        costs2 = costs1.copy()
+
+        uvs = graph.uvIds()
+
+        # random node list
+        node_list = np.random.choice(graph.numberOfNodes, size=5000, replace=False).astype('int32')
+
+        t_0 = time.time()
+        node_pairs = np.array(list(itertools.combinations(node_list, 2)))
+        set_costs_from_uv_ids(graph, costs1, node_pairs, 0)
+        print("Merging with 'set_costs_from_uv_ids' took: %f s" % (time.time() - t_0,))
+
+        t_1 = time.time()
+        set_costs_from_node_list(graph, costs2,  node_list, 0)
+        print("Merging with 'set_costs_from_node_list' took: %f s" % (time.time() - t_1,))
+
+        self.assertTrue(np.allclose(costs1, costs2))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added `set_costs_from_node_list` to interactive_backend.py, which is about to orders of magnitude faster than `itertools.combinations` + `set_costs_from_uv_ids`.
You will need to build the latest commit of my nifty branch:
https://github.com/constantinpape/nifty/commit/57612a97e97e78b1298b1e12eed42901d0ddea54
